### PR TITLE
hotfix - add export to socketdev and toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ include = [
     "socketdev",
     "socketdev.core",
     "socketdev.dependencies",
+    "socketdev.export",
     "socketdev.fullscans",
     "socketdev.npm",
     "socketdev.openapi",

--- a/socketdev/__init__.py
+++ b/socketdev/__init__.py
@@ -20,7 +20,7 @@ from socketdev.settings import Settings
 
 
 __author__ = "socket.dev"
-__version__ = "1.0.13"
+__version__ = "1.0.14"
 __all__ = ["socketdev"]
 
 
@@ -111,6 +111,7 @@ class socketdev:
         self.sbom = Sbom()
         self.purl = Purl()
         self.fullscans = FullScans()
+        self.export = Export()
         self.repositories = Repositories()
         self.repos = Repos()
         self.settings = Settings()


### PR DESCRIPTION
Didn't realize I needed to add 'Export' to the toml package list, forgot to initialize it on the `socketdev` object.

Because it's late and the last version was broken, this version is already deployed to pypi (prod and test)