### PR TITLE
updated load_files to omit the path to workspace if specified

### DIFF
--- a/socketdev/__init__.py
+++ b/socketdev/__init__.py
@@ -20,7 +20,7 @@ from socketdev.settings import Settings
 
 
 __author__ = "socket.dev"
-__version__ = "1.0.14"
+__version__ = "1.0.15"
 __all__ = ["socketdev"]
 
 

--- a/socketdev/fullscans/__init__.py
+++ b/socketdev/fullscans/__init__.py
@@ -41,9 +41,9 @@ class FullScans:
         return result
 
     @staticmethod
-    def post(files: list, params: dict) -> dict:
+    def post(files: list, params: dict, workspace: str = None) -> dict:
         loaded_files = []
-        loaded_files = load_files(files, loaded_files)
+        loaded_files = load_files(files, loaded_files, workspace)
 
         params_arg = FullScans.create_params_string(params)
 

--- a/socketdev/tools/__init__.py
+++ b/socketdev/tools/__init__.py
@@ -21,15 +21,29 @@ def fix_file_path(files) -> list:
         fixed_files.append(file)
     return fixed_files
 
+        
 
-def load_files(files: list, loaded_files: list) -> list:
+
+def load_files(files: list, loaded_files: list, workspace: str = None) -> list:
     for file in files:
         if platform.system() == "Windows":
             file = file.replace("\\", "/")
         if "/" in file:
             path, name = file.rsplit("/", 1)
+        else:
+            path = "."
+            name = file
         full_path = f"{path}/{name}"
-        payload = (full_path, (name, open(full_path, "rb")))
+        
+        # Calculate key based on workspace if provided
+        if workspace and full_path.startswith(workspace):
+            key = full_path[len(workspace):]
+            key = key.lstrip("/")
+            key = key.lstrip("./")
+        else:
+            key = full_path
+            
+        payload = (key, (name, open(full_path, "rb")))
         loaded_files.append(payload)
     return loaded_files
 


### PR DESCRIPTION
creating a new full scan wasn't working right because the workspace path was being included in the payload. This fixes that without breaking other uses of load_files