### PR TITLE
fix: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -11,9 +11,10 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
         with:
           python-version: '3.13'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,10 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3
         with:
           python-version: '3.13'
@@ -27,11 +28,13 @@ jobs:
           
       - name: Get Version
         id: version
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           RAW_VERSION=$(hatch version)
           echo "VERSION=$RAW_VERSION" >> $GITHUB_ENV
-          if [ "v$RAW_VERSION" != "${{ github.ref_name }}" ]; then
-            echo "Error: Git tag (${{ github.ref_name }}) does not match hatch version (v$RAW_VERSION)"
+          if [ "v$RAW_VERSION" != "$REF_NAME" ]; then
+            echo "Error: Git tag ($REF_NAME) does not match hatch version (v$RAW_VERSION)"
             exit 1
           fi
 

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -7,13 +7,19 @@ on:
       - 'setup.py'
       - 'pyproject.toml'
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   check_version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0  # Fetch all history for all branches
+          persist-credentials: false
 
       - name: Check version increment
         id: version_check


### PR DESCRIPTION
## Summary
- **Template injection fixes**: In `release.yml`, replaced direct `${{ github.ref_name }}` interpolation in `run:` blocks with an `env` variable (`REF_NAME`) to prevent template injection attacks.
- **Pinned actions to SHA**: Upgraded `actions/checkout` from the old pinned SHA to `v6.0.2` (`de0fac2e4500dabe0009e67214ff5f5447ce83dd`) across all three workflows (`pr-preview.yml`, `release.yml`, `version-check.yml`).
- **persist-credentials: false**: Added `persist-credentials: false` to all `actions/checkout` steps to avoid persisting the GITHUB_TOKEN in the git config.
- **Permissions**: Added a top-level `permissions` block to `version-check.yml` (contents: read, pull-requests: write, issues: write) to follow the principle of least privilege.