### PR TITLE
Harden PyPI install verification against stale cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,10 @@ jobs:
           VERSION: ${{ env.VERSION }}
         run: |
           # The first lookup can race PyPI's Simple-index propagation, and a delayed
-          # CDN purge can leave the index stale for 10+ minutes after a successful
-          # upload (socketdev 3.4.2 and socketsecurity 2.5.9 both hit this on
-          # 2026-08-05). pip caches HTTP responses by default, so without
-          # --no-cache-dir every retry can reuse that initial stale response instead
-          # of checking whether the release has appeared. Budget: 30 minutes.
+          # CDN purge can leave the index stale well after a successful upload.
+          # pip caches HTTP responses by default, so without --no-cache-dir every
+          # retry can reuse that initial stale response instead of checking whether
+          # the release has appeared. Budget: 30 minutes.
           MAX_ATTEMPTS=60
           for i in $(seq 1 "$MAX_ATTEMPTS"); do
             if python -m pip install \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           RAW_VERSION=$(hatch version)
-          echo "VERSION=$RAW_VERSION" >> $GITHUB_ENV
+          echo "VERSION=$RAW_VERSION" >> "$GITHUB_ENV"
           if [ "v$RAW_VERSION" != "$REF_NAME" ]; then
             echo "Error: Git tag ($REF_NAME) does not match hatch version (v$RAW_VERSION)"
             exit 1
@@ -38,12 +38,12 @@ jobs:
         env:
           VERSION: ${{ env.VERSION }}
         run: |
-          if curl -s -f https://pypi.org/pypi/socketdev/$VERSION/json > /dev/null; then
+          if curl -s -f "https://pypi.org/pypi/socketdev/$VERSION/json" > /dev/null; then
             echo "Version ${VERSION} already exists on PyPI"
-            echo "pypi_exists=true" >> $GITHUB_OUTPUT
+            echo "pypi_exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "Version ${VERSION} not found on PyPI - proceeding with PyPI deployment"
-            echo "pypi_exists=false" >> $GITHUB_OUTPUT
+            echo "pypi_exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build package
@@ -60,15 +60,24 @@ jobs:
         env:
           VERSION: ${{ env.VERSION }}
         run: |
-          for i in {1..30}; do
-            if pip install socketdev==${VERSION}; then
+          # The first lookup can race PyPI's Simple-index propagation. pip caches HTTP
+          # responses by default, so without --no-cache-dir every retry can reuse that
+          # initial stale response instead of checking whether the release has appeared.
+          MAX_ATTEMPTS=40
+          for i in $(seq 1 "$MAX_ATTEMPTS"); do
+            if python -m pip install \
+              --no-cache-dir \
+              --index-url https://pypi.org/simple/ \
+              "socketdev==${VERSION}"; then
               echo "Package ${VERSION} is now available and installable on PyPI"
-              pip uninstall -y socketdev
-              echo "success=true" >> $GITHUB_OUTPUT
+              python -m pip uninstall -y socketdev
+              echo "success=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            echo "Attempt $i: Package not yet installable, waiting 20s... (${i}/30)"
-            sleep 20
+            if [ "$i" -lt "$MAX_ATTEMPTS" ]; then
+              echo "Attempt $i: Package not yet installable, waiting 20s... (${i}/${MAX_ATTEMPTS})"
+              sleep 20
+            fi
           done
-          echo "success=false" >> $GITHUB_OUTPUT
+          echo "success=false" >> "$GITHUB_OUTPUT"
           exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,13 @@ jobs:
         env:
           VERSION: ${{ env.VERSION }}
         run: |
-          # The first lookup can race PyPI's Simple-index propagation. pip caches HTTP
-          # responses by default, so without --no-cache-dir every retry can reuse that
-          # initial stale response instead of checking whether the release has appeared.
-          MAX_ATTEMPTS=40
+          # The first lookup can race PyPI's Simple-index propagation, and a delayed
+          # CDN purge can leave the index stale for 10+ minutes after a successful
+          # upload (socketdev 3.4.2 and socketsecurity 2.5.9 both hit this on
+          # 2026-08-05). pip caches HTTP responses by default, so without
+          # --no-cache-dir every retry can reuse that initial stale response instead
+          # of checking whether the release has appeared. Budget: 30 minutes.
+          MAX_ATTEMPTS=60
           for i in $(seq 1 "$MAX_ATTEMPTS"); do
             if python -m pip install \
               --no-cache-dir \
@@ -74,9 +77,12 @@ jobs:
               echo "success=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
+            if curl -s -f "https://pypi.org/pypi/socketdev/${VERSION}/json" > /dev/null; then
+              echo "Release ${VERSION} exists on PyPI (JSON API) but is not in the Simple index yet - CDN propagation delay"
+            fi
             if [ "$i" -lt "$MAX_ATTEMPTS" ]; then
-              echo "Attempt $i: Package not yet installable, waiting 20s... (${i}/${MAX_ATTEMPTS})"
-              sleep 20
+              echo "Attempt $i: Package not yet installable, waiting 30s... (${i}/${MAX_ATTEMPTS})"
+              sleep 30
             fi
           done
           echo "success=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What changed

- force every post-publish install attempt to bypass pip's HTTP cache
- explicitly verify against the canonical `https://pypi.org/simple/` index
- use `python -m pip` consistently for install/uninstall
- extend verification from 10 minutes (30 × 20s) to 30 minutes (60 × 30s) and avoid sleeping after the final failure
- on failed attempts, log when the release already exists on the JSON API — making "index propagation delay" distinguishable from "publish actually failed" in the logs
- quote workflow output files and the version-check URL so the workflow passes actionlint

The verify step is now line-for-line consistent with the same hardening in SocketDev/socket-python-cli#290.

## Why

The [3.4.2 release](https://github.com/SocketDev/socket-sdk-python/actions/runs/31056518107) uploaded both distributions successfully, and PyPI's JSON API/project page showed the release, but the post-publish `pip install socketdev==3.4.2` loop repeatedly saw a stale Simple-index response whose version list ended at 3.3.0. It ultimately exhausted all 30 attempts and failed after 10m52s.

pip caches HTTP responses by default. If the first install attempt races PyPI index propagation, the existing loop can reuse that initial stale response on every retry. It also performs its 30 checks at roughly 0–580 seconds and then sleeps once more before failing, so it never makes a post-expiry check beyond the Simple index's observed 10-minute cache lifetime.

## Root cause findings (cross-repo)

This was not specific to this repo or release. [socket-python-cli](https://github.com/SocketDev/socket-python-cli) hit the identical failure the same day: [socketsecurity v2.5.9](https://pypi.org/project/socketsecurity/2.5.9/) (uploaded 16:40 UTC) failed its release verify loop with the Simple index stuck at 2.5.8 for the full 10-minute budget, which also skipped its Docker publish. Two independent packages, seven hours apart, same signature: **JSON API fresh immediately, CDN-cached Simple index stale for 10+ minutes.**

Notably, while this repo's verify loop was failing (23:30–23:39 UTC), other CI runners were successfully installing `socketdev==3.4.2` from PyPI — the staleness was specific to individual CDN cache nodes, i.e. a delayed/partial purge propagation on PyPI's side. PyPI's status page reported no incident, and pip was ruled out as a cause (the previous day's successful releases used the same pip 26.2.1). Both indexes recovered on their own.

This is a latent race rather than a package compatibility failure. The same verification loop was present in the [successful 3.3.0 release](https://github.com/SocketDev/socket-sdk-python/actions/runs/27273687985), where attempt 1 missed the new version and attempt 2 happened to find it 20 seconds later — the propagation lag has always existed; on 2026-08-05 it grew past the loop's budget.

With this change, every retry performs a fresh lookup and the retry budget extends well beyond the observed staleness window.

## Validation

- `actionlint .github/workflows/release.yml`
- parsed `.github/workflows/release.yml` with Ruby's YAML parser
- `git diff --check`

## References

Prior reports of the same PyPI Simple-index staleness class:
- pypi/warehouse#17179 — PyPI caching packages too long (release not in index hours after upload)
- pypi/warehouse#8416 — New packages not appearing in pypi.org/simple index
- pypi/warehouse#5017 — New packages not appearing in pypi.org/simple index